### PR TITLE
Enable WINE support for Linux

### DIFF
--- a/src/main/java/com/goopswagger/quickprecache/StudioMDL.java
+++ b/src/main/java/com/goopswagger/quickprecache/StudioMDL.java
@@ -12,7 +12,7 @@ public class StudioMDL {
 
         if (studioMdlVersion == Version.MISSING) {
             System.out.println("StudioMDL.exe not found, you probably installed the mod wrong.");
-            System.out.println("!!! QuickPrecache does not support linux.");
+            System.out.println("!!! IF YOU ARE ON LINUX, YOU NEED THE BIN/ FOLDER FROM A WINDOWS VERSION OF THE GAME !!!");
             throw new RuntimeException();
         }
     }
@@ -23,9 +23,7 @@ public class StudioMDL {
         String pNop4 = "-nop4";
         String pVerbose = "-verbose";
         String pFile = file;
-        ProcessBuilder builder = new ProcessBuilder(process + " " + path + " " + pGame + " " + pNop4 + " " + pVerbose + " " + pFile);
-        builder.redirectErrorStream(true);
-        Process p = builder.start();
+        Process p = createProcessCrossPlatform(process + " " + path + " " + pGame + " " + pNop4 + " " + pVerbose + " " + pFile).start();
         BufferedReader r = new BufferedReader(new InputStreamReader(p.getInputStream()));
         String line;
         while (true) {
@@ -64,6 +62,28 @@ public class StudioMDL {
 
         Version(String path) {
             this.path = path;
+        }
+    }
+
+    public static ProcessBuilder createProcessCrossPlatform(String path) throws IOException {
+        ProcessBuilder pb;
+        if (!System.getProperty("os.name").contains("Windows")) { // UNIX - run all exes through WINE
+            String[] pcmd = new String[] {"bash", "-c", "wine" + " \"" + path};
+            pb = new ProcessBuilder(pcmd);
+            pb.redirectErrorStream(true);
+
+            // debug
+            String s = "";
+            for (String st : pcmd) {
+                s = s + " " + st;
+            }
+            System.out.println(s);
+
+            return pb;
+        } else { // WinNT - native
+            pb = new ProcessBuilder(path);
+            pb.redirectErrorStream(true);
+            return pb;
         }
     }
 }


### PR DESCRIPTION
This PR adds code to automatically detect if the JVM host is not running Windows and then pass all Valve SDK tools through WINE accordingly.

A new function was created to handle this since Unix-family systems parse command arguments a little differently when called by the JVM directly, passing it through bash instead can work around this:
```
public static ProcessBuilder createProcessCrossPlatform(String path) throws IOException {
        ProcessBuilder pb;
        if (!System.getProperty("os.name").contains("Windows")) { // UNIX - run all exes through WINE
            String[] pcmd = new String[] {"bash", "-c", "wine" + " \"" + path};
            pb = new ProcessBuilder(pcmd);
            pb.redirectErrorStream(true);

            // debug
            String s = "";
            for (String st : pcmd) {
                s = s + " " + st;
            }
            System.out.println(s);

            return pb;
        } else { // WinNT - native
            pb = new ProcessBuilder(path);
            pb.redirectErrorStream(true);
            return pb;
        }
    }
```

This method is tried and tested in my own [Firestar](https://github.com/bonkmaykrQ/firestar) mod manager.